### PR TITLE
WIP: allow for restrictions and enable/disable of API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ without a dashboard or client library.
 
 ### Installer Script
 
-Use the [installer script][installer] to download and install a 
-[pre-built release][releases] of emcee for your platform 
+Use the [installer script][installer] to download and install a
+[pre-built release][releases] of emcee for your platform
 (Linux x86-64/i386/arm64 and macOS Intel/Apple Silicon).
 
 ```console
@@ -206,8 +206,8 @@ op signin
 
 <img src="https://github.com/user-attachments/assets/d639fd7c-f3bf-477c-9eb7-229285b36f7d" alt="1Password Access Requested" width="512">
 
-> [!IMPORTANT]  
-> emcee doesn't use auth credentials when downloading 
+> [!IMPORTANT]
+> emcee doesn't use auth credentials when downloading
 > OpenAPI specifications from URLs provided as command arguments.
 > If your OpenAPI specification requires authentication to access,
 > first download it to a local file using your preferred HTTP client,
@@ -218,7 +218,7 @@ op signin
 You can transform OpenAPI specifications before passing them to emcee using standard Unix utilities. This is useful for:
 - Selecting specific endpoints to expose as tools
   with [jq][jq] or [yq][yq]
-- Modifying descriptions or parameters 
+- Modifying descriptions or parameters
   with [OpenAPI Overlays][openapi-overlays]
 - Combining multiple specifications
   with [Redocly][redocly-cli]
@@ -230,6 +230,69 @@ you can use `jq` to include only the `point` tool from `weather.gov`.
 cat path/to/openapi.json | \
   jq 'if .paths then .paths |= with_entries(select(.key == "/points/{point}")) else . end' | \
   emcee
+```
+
+### Disabling Operations
+
+You can selectively disable certain API operations or endpoints using a configuration file. This is useful when you want to limit access to destructive operations like DELETE or specific sensitive endpoints.
+
+Create a JSON configuration file with the following structure:
+
+```json
+{
+  "disabledOperations": {
+    "get": false,
+    "post": false,
+    "put": false,
+    "delete": true,  // Disable all DELETE operations
+    "patch": false,
+    "head": false,
+    "options": false
+  },
+  "disabledEndpoints": [
+    "createUser",    // Disable specific operations by OperationId
+    "updateSensitiveData"
+  ],
+  "disabledPaths": [
+    "/admin/.*"      // Disable paths matching regex patterns (not yet implemented)
+  ]
+}
+```
+
+Then provide the path to this configuration file when using emcee:
+
+```console
+emcee --config path/to/config.json https://api.example.com/openapi.json
+```
+
+Or in Claude Desktop's configuration:
+
+```json
+{
+  "mcpServers": {
+    "myapi": {
+      "command": "emcee",
+      "args": [
+        "--config", "/path/to/config.json",
+        "https://api.example.com/openapi.json"
+      ]
+    }
+  }
+}
+```
+
+An additional demonstration using the weather API `api.weather.gov`. To test this with Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "weather-restricted": {
+      "command": "emcee",
+      "args": [
+        "--config", "path/to/repo/emcee-config-no-alerts.json",
+        "https://api.weather.gov/openapi.json"
+      ]
+    }
 ```
 
 

--- a/cmd/emcee/main.go
+++ b/cmd/emcee/main.go
@@ -197,6 +197,11 @@ Authentication values can be provided directly or as 1Password secret references
 			// Set spec data
 			opts = append(opts, mcp.WithSpecData(specData))
 
+			// Apply configuration if provided
+			if configFile != "" {
+				opts = append(opts, mcp.WithConfigFile(configFile))
+			}
+
 			// Create server
 			server, err := mcp.NewServer(opts...)
 			if err != nil {
@@ -216,6 +221,7 @@ var (
 	bearerAuth string
 	basicAuth  string
 	rawAuth    string
+	configFile string
 
 	retries int
 	timeout time.Duration
@@ -233,6 +239,7 @@ func init() {
 	rootCmd.Flags().StringVar(&bearerAuth, "bearer-auth", "", "Bearer token value (will be prefixed with 'Bearer ')")
 	rootCmd.Flags().StringVar(&basicAuth, "basic-auth", "", "Basic auth value (either user:pass or base64 encoded, will be prefixed with 'Basic ')")
 	rootCmd.Flags().StringVar(&rawAuth, "raw-auth", "", "Raw value for Authorization header")
+	rootCmd.Flags().StringVar(&configFile, "config", "", "Path to configuration file for customizing API access")
 	rootCmd.MarkFlagsMutuallyExclusive("bearer-auth", "basic-auth", "raw-auth")
 
 	rootCmd.Flags().IntVar(&retries, "retries", 3, "Maximum number of retries for failed requests")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,138 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// EmceeConfig represents the configuration for the emcee service
+type EmceeConfig struct {
+	// DisabledOperations specifies which HTTP operations are disabled
+	DisabledOperations Operations `json:"disabledOperations"`
+	
+	// DisabledEndpoints specifies which specific endpoints are disabled
+	DisabledEndpoints []string `json:"disabledEndpoints"`
+	
+	// DisabledPaths specifies which paths (as regex patterns) are disabled
+	DisabledPaths []string `json:"disabledPaths"`
+}
+
+// Operations represents which HTTP operations are enabled/disabled
+type Operations struct {
+	GET     bool `json:"get"`
+	POST    bool `json:"post"`
+	PUT     bool `json:"put"`
+	DELETE  bool `json:"delete"`
+	PATCH   bool `json:"patch"`
+	HEAD    bool `json:"head"`
+	OPTIONS bool `json:"options"`
+}
+
+// DefaultConfig returns a default configuration with all operations enabled
+func DefaultConfig() *EmceeConfig {
+	return &EmceeConfig{
+		DisabledOperations: Operations{
+			GET:     false,
+			POST:    false,
+			PUT:     false,
+			DELETE:  false,
+			PATCH:   false,
+			HEAD:    false,
+			OPTIONS: false,
+		},
+		DisabledEndpoints: []string{},
+		DisabledPaths:     []string{},
+	}
+}
+
+// LoadFile loads configuration from a file
+func LoadFile(path string) (*EmceeConfig, error) {
+	if path == "" {
+		return DefaultConfig(), nil
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DefaultConfig(), nil
+		}
+		return nil, fmt.Errorf("error opening config file: %w", err)
+	}
+	defer f.Close()
+
+	return Load(f)
+}
+
+// Load loads configuration from an io.Reader
+func Load(r io.Reader) (*EmceeConfig, error) {
+	config := DefaultConfig()
+	
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("error reading config data: %w", err)
+	}
+	
+	if err := json.Unmarshal(data, config); err != nil {
+		return nil, fmt.Errorf("error parsing config JSON: %w", err)
+	}
+	
+	return config, nil
+}
+
+// IsOperationDisabled checks if a specific HTTP operation is disabled
+func (c *EmceeConfig) IsOperationDisabled(method string) bool {
+	method = strings.ToUpper(method)
+	
+	switch method {
+	case "GET":
+		return c.DisabledOperations.GET
+	case "POST":
+		return c.DisabledOperations.POST
+	case "PUT":
+		return c.DisabledOperations.PUT
+	case "DELETE":
+		return c.DisabledOperations.DELETE
+	case "PATCH":
+		return c.DisabledOperations.PATCH
+	case "HEAD":
+		return c.DisabledOperations.HEAD
+	case "OPTIONS":
+		return c.DisabledOperations.OPTIONS
+	default:
+		return false
+	}
+}
+
+// IsEndpointDisabled checks if a specific operation ID is in the disabled list
+func (c *EmceeConfig) IsEndpointDisabled(operationID string) bool {
+	for _, disabled := range c.DisabledEndpoints {
+		if disabled == operationID {
+			return true
+		}
+	}
+	return false
+}
+
+// Save writes the configuration to a file
+func (c *EmceeConfig) Save(path string) error {
+	// Create parent directories if they don't exist
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("error creating config directory: %w", err)
+	}
+	
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshaling config: %w", err)
+	}
+	
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("error writing config file: %w", err)
+	}
+	
+	return nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,164 @@
+package config
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	
+	// Verify all operations are enabled by default
+	if cfg.DisabledOperations.GET {
+		t.Error("GET should be enabled by default")
+	}
+	if cfg.DisabledOperations.POST {
+		t.Error("POST should be enabled by default")
+	}
+	if cfg.DisabledOperations.PUT {
+		t.Error("PUT should be enabled by default")
+	}
+	if cfg.DisabledOperations.DELETE {
+		t.Error("DELETE should be enabled by default")
+	}
+	if cfg.DisabledOperations.PATCH {
+		t.Error("PATCH should be enabled by default")
+	}
+	if cfg.DisabledOperations.HEAD {
+		t.Error("HEAD should be enabled by default")
+	}
+	if cfg.DisabledOperations.OPTIONS {
+		t.Error("OPTIONS should be enabled by default")
+	}
+	
+	// Verify empty disabled endpoints and paths
+	if len(cfg.DisabledEndpoints) != 0 {
+		t.Error("DisabledEndpoints should be empty by default")
+	}
+	if len(cfg.DisabledPaths) != 0 {
+		t.Error("DisabledPaths should be empty by default")
+	}
+}
+
+func TestLoad(t *testing.T) {
+	jsonConfig := `{
+		"disabledOperations": {
+			"get": false,
+			"post": false,
+			"put": false,
+			"delete": true,
+			"patch": false,
+			"head": true,
+			"options": false
+		},
+		"disabledEndpoints": [
+			"createUser",
+			"deleteItem"
+		],
+		"disabledPaths": [
+			"/admin/.*"
+		]
+	}`
+	
+	cfg, err := Load(bytes.NewBufferString(jsonConfig))
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+	
+	// Verify disabled operations
+	if cfg.DisabledOperations.GET {
+		t.Error("GET should be enabled")
+	}
+	if cfg.DisabledOperations.DELETE != true {
+		t.Error("DELETE should be disabled")
+	}
+	if cfg.DisabledOperations.HEAD != true {
+		t.Error("HEAD should be disabled")
+	}
+	
+	// Verify disabled endpoints
+	if len(cfg.DisabledEndpoints) != 2 {
+		t.Errorf("Expected 2 disabled endpoints, got %d", len(cfg.DisabledEndpoints))
+	}
+	if cfg.DisabledEndpoints[0] != "createUser" {
+		t.Errorf("Expected first disabled endpoint to be 'createUser', got '%s'", cfg.DisabledEndpoints[0])
+	}
+	if cfg.DisabledEndpoints[1] != "deleteItem" {
+		t.Errorf("Expected second disabled endpoint to be 'deleteItem', got '%s'", cfg.DisabledEndpoints[1])
+	}
+	
+	// Verify disabled paths
+	if len(cfg.DisabledPaths) != 1 {
+		t.Errorf("Expected 1 disabled path, got %d", len(cfg.DisabledPaths))
+	}
+	if cfg.DisabledPaths[0] != "/admin/.*" {
+		t.Errorf("Expected disabled path to be '/admin/.*', got '%s'", cfg.DisabledPaths[0])
+	}
+}
+
+func TestIsOperationDisabled(t *testing.T) {
+	cfg := &EmceeConfig{
+		DisabledOperations: Operations{
+			GET:     false,
+			POST:    false,
+			PUT:     false,
+			DELETE:  true,
+			PATCH:   false,
+			HEAD:    true,
+			OPTIONS: false,
+		},
+	}
+	
+	// Test cases
+	testCases := []struct {
+		method   string
+		expected bool
+	}{
+		{"GET", false},
+		{"get", false},
+		{"POST", false},
+		{"PUT", false},
+		{"DELETE", true},
+		{"delete", true},
+		{"PATCH", false},
+		{"HEAD", true},
+		{"OPTIONS", false},
+		{"UNKNOWN", false}, // Unknown methods should not be disabled
+	}
+	
+	for _, tc := range testCases {
+		t.Run(tc.method, func(t *testing.T) {
+			result := cfg.IsOperationDisabled(tc.method)
+			if result != tc.expected {
+				t.Errorf("IsOperationDisabled(%s) = %v, expected %v", tc.method, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsEndpointDisabled(t *testing.T) {
+	cfg := &EmceeConfig{
+		DisabledEndpoints: []string{"createUser", "deleteItem"},
+	}
+	
+	// Test cases
+	testCases := []struct {
+		operationID string
+		expected    bool
+	}{
+		{"createUser", true},
+		{"updateUser", false},
+		{"deleteItem", true},
+		{"getItems", false},
+		{"", false}, // Empty operation ID should not be disabled
+	}
+	
+	for _, tc := range testCases {
+		t.Run(tc.operationID, func(t *testing.T) {
+			result := cfg.IsEndpointDisabled(tc.operationID)
+			if result != tc.expected {
+				t.Errorf("IsEndpointDisabled(%s) = %v, expected %v", tc.operationID, result, tc.expected)
+			}
+		})
+	}
+}

--- a/testdata/emcee-config-no-alerts.json
+++ b/testdata/emcee-config-no-alerts.json
@@ -1,0 +1,24 @@
+{
+  "disabledOperations": {
+    "get": false,
+    "post": false,
+    "put": false,
+    "delete": true,
+    "patch": false,
+    "head": false,
+    "options": false
+  },
+  "disabledEndpoints": [
+    "alerts_query",
+    "alerts_active",
+    "alerts_active_count",
+    "alerts_active_zone",
+    "alerts_active_area",
+    "alerts_active_region",
+    "alerts_types",
+    "alerts_single"
+  ],
+  "disabledPaths": [
+    "/alerts/.*"
+  ]
+}

--- a/testdata/emcee-config.json
+++ b/testdata/emcee-config.json
@@ -1,0 +1,20 @@
+{
+  "disabledOperations": {
+    "get": false,
+    "post": false,
+    "put": false,
+    "delete": true,
+    "patch": false,
+    "head": false,
+    "options": false
+  },
+  "disabledEndpoints": [
+    "createResource",
+    "updateSensitiveData",
+    "getAdminAccess"
+  ],
+  "disabledPaths": [
+    "/admin/.*",
+    "/v1/internal/.*"
+  ]
+}


### PR DESCRIPTION
Currently there is no way to enable or disable specific endpoints. This is fine when using claude but when attempting to use smaller models the amount of tools available may overwhelm smaller models.