### PR TITLE
Add tool annotations

### DIFF
--- a/cmd/emcee/main.go
+++ b/cmd/emcee/main.go
@@ -192,7 +192,11 @@ Authentication values can be provided directly or as 1Password secret references
 			// Create SDK server and register tools from OpenAPI
 			impl := &mcp.Implementation{Name: cmd.Name(), Version: version}
 			server := mcp.NewServer(impl, nil)
-			if err := internal.RegisterTools(server, specData, client); err != nil {
+			var opts []internal.RegisterToolsOption
+			if noAnnotations {
+				opts = append(opts, internal.WithoutAnnotations())
+			}
+			if err := internal.RegisterTools(server, specData, client, opts...); err != nil {
 				return fmt.Errorf("error registering tools: %w", err)
 			}
 
@@ -213,8 +217,9 @@ var (
 	timeout time.Duration
 	rps     int
 
-	verbose bool
-	silent  bool
+	verbose       bool
+	silent        bool
+	noAnnotations bool
 
 	version = "dev"
 	commit  = "none"
@@ -234,6 +239,8 @@ func init() {
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable debug level logging to stderr")
 	rootCmd.Flags().BoolVarP(&silent, "silent", "s", false, "Disable all logging")
 	rootCmd.MarkFlagsMutuallyExclusive("verbose", "silent")
+
+	rootCmd.Flags().BoolVar(&noAnnotations, "no-annotations", false, "Disable generated tool annotations")
 
 	rootCmd.Version = fmt.Sprintf("%s (commit: %s, built at: %s)", version, commit, date)
 }

--- a/internal/openapi.go
+++ b/internal/openapi.go
@@ -21,9 +21,22 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// RegisterToolsOption configures RegisterTools behavior.
+type RegisterToolsOption func(*registerToolsConfig)
+
+type registerToolsConfig struct {
+	enableAnnotations bool
+}
+
+// WithoutAnnotations disables attaching REST-aware MCP ToolAnnotations for generated tools.
+func WithoutAnnotations() RegisterToolsOption {
+	return func(cfg *registerToolsConfig) { cfg.enableAnnotations = false }
+}
+
 // RegisterTools parses the given OpenAPI specification and registers tools on the provided MCP server.
 // All HTTP calls are executed using the provided http.Client. If the client is nil, http.DefaultClient is used.
-func RegisterTools(server *mcp.Server, specData []byte, client *http.Client) error {
+// By default, REST-aware MCP ToolAnnotations are attached to each tool. Pass options to change behavior.
+func RegisterTools(server *mcp.Server, specData []byte, client *http.Client, opts ...RegisterToolsOption) error {
 	if len(specData) == 0 {
 		return fmt.Errorf("no OpenAPI spec data provided")
 	}
@@ -32,6 +45,14 @@ func RegisterTools(server *mcp.Server, specData []byte, client *http.Client) err
 	}
 	if client == nil {
 		client = http.DefaultClient
+	}
+
+	// Defaults
+	cfg := &registerToolsConfig{enableAnnotations: true}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(cfg)
+		}
 	}
 
 	doc, err := libopenapi.NewDocument(specData)
@@ -117,44 +138,46 @@ func RegisterTools(server *mcp.Server, specData []byte, client *http.Client) err
 				}
 			}
 
-			// Derive MCP ToolAnnotations from REST conventions
-			title := op.op.Summary
-			if title == "" {
-				title = fmt.Sprintf("%s %s", op.method, p)
-			}
-			openWorld := true
-			destructiveTrue := true
-			ann := &mcp.ToolAnnotations{
-				Title:         title,
-				OpenWorldHint: &openWorld,
-			}
-			switch op.method {
-			case "GET":
-				ann.ReadOnlyHint = true
-				ann.IdempotentHint = true
-			case "POST":
-				ann.ReadOnlyHint = false
-				ann.IdempotentHint = false
-				ann.DestructiveHint = &destructiveTrue
-			case "PUT":
-				ann.ReadOnlyHint = false
-				ann.IdempotentHint = true
-				ann.DestructiveHint = &destructiveTrue
-			case "PATCH":
-				ann.ReadOnlyHint = false
-				ann.IdempotentHint = false
-				ann.DestructiveHint = &destructiveTrue
-			case "DELETE":
-				ann.ReadOnlyHint = false
-				ann.IdempotentHint = true
-				ann.DestructiveHint = &destructiveTrue
-			}
-
 			tool := &mcp.Tool{
 				Name:        toolName,
 				Description: desc,
 				InputSchema: schema,
-				Annotations: ann,
+			}
+
+			if cfg.enableAnnotations {
+				// Derive MCP ToolAnnotations from REST conventions
+				title := op.op.Summary
+				if title == "" {
+					title = fmt.Sprintf("%s %s", op.method, p)
+				}
+				openWorld := true
+				destructiveTrue := true
+				ann := &mcp.ToolAnnotations{
+					Title:         title,
+					OpenWorldHint: &openWorld,
+				}
+				switch op.method {
+				case "GET":
+					ann.ReadOnlyHint = true
+					ann.IdempotentHint = true
+				case "POST":
+					ann.ReadOnlyHint = false
+					ann.IdempotentHint = false
+					ann.DestructiveHint = &destructiveTrue
+				case "PUT":
+					ann.ReadOnlyHint = false
+					ann.IdempotentHint = true
+					ann.DestructiveHint = &destructiveTrue
+				case "PATCH":
+					ann.ReadOnlyHint = false
+					ann.IdempotentHint = false
+					ann.DestructiveHint = &destructiveTrue
+				case "DELETE":
+					ann.ReadOnlyHint = false
+					ann.IdempotentHint = true
+					ann.DestructiveHint = &destructiveTrue
+				}
+				tool.Annotations = ann
 			}
 
 			// Capture for handler


### PR DESCRIPTION
See https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations

This PR adds tool annotations based on REST conventions for HTTP verbs in the OpenAPI schema.  

This is enabled by default, and can be disabled with the `--no-annotations` option.